### PR TITLE
[AXE-1073]F: use FQDN to increase DNS resolution speed

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -28,7 +28,7 @@ namespace: ""
 namespaceCreate: false
 
 ## clusterDomain as defined for your k8s cluster
-clusterDomain: cluster.local
+clusterDomain: cluster.local.
 
 ###
 ### Global Settings


### PR DESCRIPTION
팟의 도메인을 이용해서 통신하는 경우 DNS 질의가 일어나는데, Fully Qualified Domain Name을 이용하면 쿼리가 단 1회만 실행되어 성능개선을 도모할 수 있다고 합니다
그래서 적용했습니다